### PR TITLE
feat(language support): Add aws-lambda-nodejs-rollup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ This section includes code libraries in various programming languages which vend
 
 * [AWS-CDK-Kotlin-DSL](https://github.com/justincase-jp/AWS-CDK-Kotlin-DSL) - A Wrapper library of [AWS CDK Java](https://mvnrepository.com/artifact/software.amazon.awscdk). CI automatically generates code and deploys it by daily.
 * [aws-cdk-maven-plugin](https://github.com/LinguaRobot/aws-cdk-maven-plugin) - A plugin to define and deploy your AWS CDK applications using Java and Maven.
+* [aws-lambda-nodejs-rollup](https://github.com/vvo/aws-lambda-nodejs-rollup) - Alternative Node.js lambda CDK construct, [using rollup.js](https://rollupjs.org/).
 
 ## Library Publishing
 


### PR DESCRIPTION
This is an alternative Node.js lambda construct using rollup.js for bundling. Bundling happens locally (not in docker), in temporary directories.