### PR TITLE
Proposed aws-cdk-billing-alarm in monitoring constructs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ This section includes code libraries in various programming languages which vend
 ### Monitoring
 
 * [cdk-watchful](https://github.com/eladb/cdk-watchful) - Automatic dashboards and alarms for CDK apps.
+* [aws-cdk-billing-alarm](https://github.com/alvyn279/aws-cdk-billing-alarm) - Construct that sets up email alerts for exceeding an amount on your AWS bill.
 
 ### Workflows
 


### PR DESCRIPTION
I'm proposing [aws-cdk-billing-alarm](https://github.com/alvyn279/aws-cdk-billing-alarm).

I built this to automate the creation of a billing alert for your AWS bill. Feel free to leave feedback/deny this pull request.