### PR TITLE
Adding "AWS CDK Continuous Integration and Delivery Using Travis CI" …

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@ This section includes code libraries in various programming languages which vend
 * [Introducing AWS CDK with a real life Lambda and API gateway example](https://a.l3x.in/2020/02/04/migrating-from-terraform-to-cdk.html) - By Alexander Fortin.
 * [CloudWatch Dashboards as Code (the Right Way) Using AWS CDK](https://medium.com/poka-techblog/cloudwatch-dashboards-as-code-the-right-way-using-aws-cdk-1453309c5481) - By Simon-Pierre Gingras.
 * [Coding the Jamstack missing parts: databases, crons & background jobs](https://dev.to/vvo/coding-the-jamstack-missing-parts-databases-crons-background-jobs-1bpj) - By Vincent Voyer.
+* [AWS CDK Continuous Integration and Delivery Using Travis CI](https://medium.com/better-programming/aws-cdk-continuous-integration-and-delivery-using-travis-ci-ee5dd7549434) - By Thomas Poignant.
 
 ## Related Projects
 


### PR DESCRIPTION
Adding a link to a blog post on how to deploy CDK stack using travis CI.